### PR TITLE
Amélioration visuelle du jeu

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,11 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <title>Sentence Sprint</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <div id="scrambled" class="big"></div>
-    <div id="timer" class="big"></div>
+    <div id="timer" class="big"><span id="timerText"></span></div>
     <button id="revealBtn" aria-label="Révéler">Révéler</button>
     <button id="nextBtn" aria-label="Manche suivante" hidden>Manche suivante</button>
 

--- a/script.js
+++ b/script.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
     const scrambledEl = document.getElementById('scrambled');
     const timerEl = document.getElementById('timer');
+    const timerText = document.getElementById('timerText');
     const revealBtn = document.getElementById('revealBtn');
     const nextBtn = document.getElementById('nextBtn');
     const settingsBtn = document.getElementById('settingsBtn');
@@ -64,13 +65,19 @@ document.addEventListener('DOMContentLoaded', () => {
         return words;
     }
 
+    function updateTimerDisplay() {
+        timerText.textContent = timeLeft;
+        const angle = (timeLeft / data.duration) * 360;
+        timerEl.style.background = `conic-gradient(#4caf50 ${angle}deg, rgba(0,0,0,0.1) 0deg)`;
+    }
+
     function startTimer() {
         stopTimer();
         timeLeft = data.duration;
-        timerEl.textContent = timeLeft;
+        updateTimerDisplay();
         timer = setInterval(() => {
             timeLeft--;
-            timerEl.textContent = timeLeft;
+            updateTimerDisplay();
             if (timeLeft <= 0) {
                 stopTimer();
                 revealBtn.disabled = false;
@@ -83,6 +90,7 @@ document.addEventListener('DOMContentLoaded', () => {
             clearInterval(timer);
             timer = null;
         }
+        updateTimerDisplay();
     }
 
     function updateScoreboard() {
@@ -139,16 +147,16 @@ document.addEventListener('DOMContentLoaded', () => {
         revealBtn.disabled = true;
         revealBtn.hidden = false;
         nextBtn.hidden = true;
-        timerEl.textContent = '';
+        timerText.textContent = '';
         currentSentence = getRandomSentence();
         const words = shuffleWords(currentSentence);
-        scrambledEl.textContent = words.join(' ');
+        scrambledEl.innerHTML = words.map(w => `<span class="word">${w}</span>`).join(' ');
         startTimer();
     }
 
     function reveal() {
         stopTimer();
-        scrambledEl.innerHTML = `${scrambledEl.textContent}<br><em>${currentSentence}</em>`;
+        scrambledEl.innerHTML = `${scrambledEl.innerHTML}<br><em>${currentSentence}</em>`;
         revealBtn.hidden = true;
         nextBtn.hidden = false;
     }
@@ -161,7 +169,8 @@ document.addEventListener('DOMContentLoaded', () => {
             html += `${idx + 1}. ${entry[0]} – ${entry[1]}<br>`;
         });
         scrambledEl.innerHTML = html;
-        timerEl.textContent = '';
+        timerText.textContent = '';
+        timerEl.style.background = 'conic-gradient(#4caf50 0deg, rgba(0,0,0,0.1) 0deg)';
         revealBtn.hidden = true;
         nextBtn.hidden = true;
     }

--- a/style.css
+++ b/style.css
@@ -1,32 +1,44 @@
 body {
-    font-family: "Segoe UI", Roboto, sans-serif;
+    font-family: 'Poppins', sans-serif;
     margin: 0;
     padding: 20px;
     min-height: 100vh;
     display: flex;
     flex-direction: column;
     align-items: center;
-    background: linear-gradient(135deg, #0f2027, #203a43, #2c5364);
-    color: #fff;
+    background: linear-gradient(135deg, #d8f3dc, #b7e4c7, #95d5b2);
+    background-size: 400% 400%;
+    animation: bgMove 15s ease infinite;
+    color: #063;
+}
+
+@keyframes bgMove {
+    0% { background-position: 0% 50%; }
+    50% { background-position: 100% 50%; }
+    100% { background-position: 0% 50%; }
 }
 
 .big {
     font-size: 6vw;
     text-align: center;
     margin: 1rem 0;
-    text-shadow: 0 2px 4px rgba(0,0,0,0.6);
+    text-shadow: 0 2px 4px rgba(0,0,0,0.2);
 }
 
 #scores {
     position: fixed;
+    left: 0;
     right: 0;
-    top: 0;
-    max-width: 25%;
-    padding: 1rem;
-    font-size: 1.5rem;
-    background: rgba(255, 255, 255, 0.15);
-    border-radius: 10px;
-    backdrop-filter: blur(8px);
+    bottom: 0;
+    padding: 0.5rem 1rem 1rem;
+    font-size: 1.3rem;
+    background: rgba(255, 255, 255, 0.3);
+    border-top-left-radius: 10px;
+    border-top-right-radius: 10px;
+    backdrop-filter: blur(6px);
+    max-height: 40vh;
+    overflow-y: auto;
+    color: #042;
 }
 
 #scores ul {
@@ -63,21 +75,51 @@ body {
     flex-grow: 1;
 }
 
+.word {
+    display: inline-block;
+    margin: 0.2rem;
+    padding: 0.3rem 0.5rem;
+    background: rgba(255, 255, 255, 0.6);
+    color: #042;
+    border-radius: 6px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+#timer {
+    position: relative;
+    width: 20vmin;
+    height: 20vmin;
+    max-width: 150px;
+    max-height: 150px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: conic-gradient(#4caf50 0deg, rgba(0,0,0,0.1) 0deg);
+}
+
+#timerText {
+    position: absolute;
+    font-size: 3vmin;
+    font-weight: 700;
+    color: #042;
+}
+
 button {
     font-size: 1.2rem;
     padding: 0.6rem 1.2rem;
     margin: 0.5rem;
-    color: #fff;
-    background: rgba(255, 255, 255, 0.1);
+    color: #042;
+    background: rgba(255, 255, 255, 0.8);
     border: none;
     border-radius: 8px;
-    box-shadow: 0 4px 0 rgba(0, 0, 0, 0.3);
+    box-shadow: 0 4px 0 rgba(0, 0, 0, 0.15);
     backdrop-filter: blur(4px);
     transition: transform 0.1s, box-shadow 0.1s, background 0.3s;
 }
 
 button:hover {
-    background: rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 1);
 }
 
 button:active {


### PR DESCRIPTION
## Summary
- change visual theme to use light green hues
- load the Poppins font for a modern look
- show each shuffled word in its own box
- move the scoreboard to the bottom
- add animated background and circular timer

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684030cd59fc8331b6cf4e47b41b8068