### PR TITLE
Improve scoreboard layout and sorting

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,6 @@
 
     <aside id="scores">
         <h2>Scores</h2>
-        <p class="hint">Utilisez "+" ou "-" pour corriger les points.</p>
         <ul id="scoreList"></ul>
     </aside>
 

--- a/script.js
+++ b/script.js
@@ -95,7 +95,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function updateScoreboard() {
         scoreList.innerHTML = '';
-        data.names.forEach(name => {
+        const sortedNames = [...data.names].sort((a, b) => data.scores[b] - data.scores[a]);
+        sortedNames.forEach(name => {
             if (data.scores[name] == null) data.scores[name] = 0;
             const li = document.createElement('li');
             li.dataset.name = name;
@@ -109,8 +110,8 @@ document.addEventListener('DOMContentLoaded', () => {
             addBtn.textContent = '+';
             addBtn.addEventListener('click', () => {
                 data.scores[name]++;
-                label.textContent = `${name} – ${data.scores[name]}`;
                 saveData();
+                updateScoreboard();
             });
 
             const subBtn = document.createElement('button');
@@ -118,8 +119,8 @@ document.addEventListener('DOMContentLoaded', () => {
             subBtn.textContent = '−';
             subBtn.addEventListener('click', () => {
                 data.scores[name]--;
-                label.textContent = `${name} – ${data.scores[name]}`;
                 saveData();
+                updateScoreboard();
             });
 
             li.appendChild(label);

--- a/style.css
+++ b/style.css
@@ -30,13 +30,13 @@ body {
     left: 0;
     right: 0;
     bottom: 0;
-    padding: 0.5rem 1rem 1rem;
-    font-size: 1.3rem;
+    padding: 0.3rem 0.5rem;
+    font-size: 1rem;
     background: rgba(255, 255, 255, 0.3);
     border-top-left-radius: 10px;
     border-top-right-radius: 10px;
     backdrop-filter: blur(6px);
-    max-height: 40vh;
+    max-height: 3cm;
     overflow-y: auto;
     color: #042;
 }
@@ -45,6 +45,10 @@ body {
     list-style: none;
     margin: 0;
     padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.2rem 0.6rem;
 }
 
 #scores h2 {
@@ -52,27 +56,21 @@ body {
     text-align: center;
 }
 
-.hint {
-    font-size: 0.8rem;
-    margin: 0 0 0.5rem 0;
-    text-align: center;
-}
 
 #scoreList li {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    margin: 0.5rem 0;
+    margin: 0;
 }
 
 .score-btn {
-    margin-left: 0.3rem;
+    margin-left: 0.2rem;
     padding: 0.2rem 0.5rem;
     font-size: 1rem;
 }
 
 .score-label {
-    flex-grow: 1;
+    margin-right: 0.2rem;
 }
 
 .word {


### PR DESCRIPTION
## Summary
- limit scoreboard height to 3cm
- let scoreboard items wrap in multiple columns
- remove outdated hint text
- sort players by score and refresh on score change

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_6840345cd7008331acf14230a9c91fb8