### PR TITLE
Improve scoreboard layout and controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
     <aside id="scores">
         <h2>Scores</h2>
         <ul id="scoreList"></ul>
+        <button id="resetScores" aria-label="Réinitialiser">Réinitialiser</button>
     </aside>
 
     <button id="settingsBtn" aria-label="Paramètres">Paramètres</button>

--- a/script.js
+++ b/script.js
@@ -10,6 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const namesInput = document.getElementById('namesInput');
     const durationInput = document.getElementById('durationInput');
     const saveSettingsBtn = document.getElementById('saveSettings');
+    const resetScoresBtn = document.getElementById('resetScores');
     const scoreList = document.getElementById('scoreList');
 
     let data = loadData();
@@ -101,31 +102,26 @@ document.addEventListener('DOMContentLoaded', () => {
             const li = document.createElement('li');
             li.dataset.name = name;
 
-            const label = document.createElement('span');
-            label.className = 'score-label';
-            label.textContent = `${name} – ${data.scores[name]}`;
-
-            const addBtn = document.createElement('button');
-            addBtn.className = 'score-btn';
-            addBtn.textContent = '+';
-            addBtn.addEventListener('click', () => {
-                data.scores[name]++;
-                saveData();
-                updateScoreboard();
-            });
-
-            const subBtn = document.createElement('button');
-            subBtn.className = 'score-btn';
-            subBtn.textContent = '−';
-            subBtn.addEventListener('click', () => {
+            const nameSpan = document.createElement('span');
+            nameSpan.className = 'score-name';
+            nameSpan.textContent = name;
+            nameSpan.addEventListener('click', () => {
                 data.scores[name]--;
                 saveData();
                 updateScoreboard();
             });
 
-            li.appendChild(label);
-            li.appendChild(addBtn);
-            li.appendChild(subBtn);
+            const valueSpan = document.createElement('span');
+            valueSpan.className = 'score-value';
+            valueSpan.textContent = data.scores[name];
+            valueSpan.addEventListener('click', () => {
+                data.scores[name]++;
+                saveData();
+                updateScoreboard();
+            });
+
+            li.appendChild(nameSpan);
+            li.appendChild(valueSpan);
             scoreList.appendChild(li);
         });
     }
@@ -200,5 +196,13 @@ document.addEventListener('DOMContentLoaded', () => {
         updateScoreboard();
         played = [];
         nextRound();
+    });
+
+    resetScoresBtn.addEventListener('click', () => {
+        Object.keys(data.scores).forEach(name => {
+            data.scores[name] = 0;
+        });
+        saveData();
+        updateScoreboard();
     });
 });

--- a/style.css
+++ b/style.css
@@ -6,6 +6,7 @@ body {
     display: flex;
     flex-direction: column;
     align-items: center;
+    margin-right: 190px;
     background: linear-gradient(135deg, #d8f3dc, #b7e4c7, #95d5b2);
     background-size: 400% 400%;
     animation: bgMove 15s ease infinite;
@@ -27,16 +28,16 @@ body {
 
 #scores {
     position: fixed;
-    left: 0;
-    right: 0;
+    top: 0;
     bottom: 0;
-    padding: 0.3rem 0.5rem;
-    font-size: 1rem;
+    right: 0;
+    width: 180px;
+    padding: 0.5rem;
+    font-size: 0.8rem;
     background: rgba(255, 255, 255, 0.3);
     border-top-left-radius: 10px;
-    border-top-right-radius: 10px;
+    border-bottom-left-radius: 10px;
     backdrop-filter: blur(6px);
-    max-height: 3cm;
     overflow-y: auto;
     color: #042;
 }
@@ -45,10 +46,6 @@ body {
     list-style: none;
     margin: 0;
     padding: 0;
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 0.2rem 0.6rem;
 }
 
 #scores h2 {
@@ -60,17 +57,22 @@ body {
 #scoreList li {
     display: flex;
     align-items: center;
-    margin: 0;
+    justify-content: space-between;
+    margin: 0.2rem 0;
 }
 
-.score-btn {
-    margin-left: 0.2rem;
-    padding: 0.2rem 0.5rem;
-    font-size: 1rem;
+.score-name {
+    cursor: pointer;
 }
 
-.score-label {
-    margin-right: 0.2rem;
+.score-value {
+    cursor: pointer;
+    background: rgba(255,255,255,0.8);
+    padding: 0.1rem 0.4rem;
+    border-radius: 4px;
+    min-width: 1.4rem;
+    text-align: center;
+    font-weight: 700;
 }
 
 .word {
@@ -133,4 +135,13 @@ dialog {
     border: none;
     border-radius: 10px;
     backdrop-filter: blur(10px);
+}
+
+#settingsBtn {
+    position: fixed;
+    top: 0.5rem;
+    left: 0.5rem;
+    font-size: 0.8rem;
+    padding: 0.2rem 0.4rem;
+    margin: 0;
 }


### PR DESCRIPTION
## Summary
- move settings button to top left
- keep scores docked to the right and list players vertically
- tap on score to add and tap on name to subtract
- add reset scores button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684039c78304833185d614c7ea4e1422